### PR TITLE
remove depracated uneeded bottle tag and fixing shebang python on files

### DIFF
--- a/orthofinder.rb
+++ b/orthofinder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,13 +14,11 @@ class Orthofinder < Formula
   include Language::Python::Shebang
   include Language::Python::Virtualenv
 
-  desc "OrthoFinder: phylogenetic orthology inference for comparative genomics"
-  homepage "https://davidemms.github.io/"
-  url "https://github.com/davidemms/OrthoFinder/releases/download/2.5.4/OrthoFinder_source.tar.gz"
-  sha256 "a735c81999e8e3026ad62536b14e5b0391c9fc632f872f99857936ac60003ba5"
-  version "2.5.4"
-
-  bottle :unneeded
+  desc 'OrthoFinder: phylogenetic orthology inference for comparative genomics'
+  homepage 'https://davidemms.github.io/'
+  url 'https://github.com/davidemms/OrthoFinder/releases/download/2.5.4/OrthoFinder_source.tar.gz'
+  sha256 'a735c81999e8e3026ad62536b14e5b0391c9fc632f872f99857936ac60003ba5'
+  version '2.5.4'
 
   depends_on 'python@3'
   depends_on 'ensembl/external/diamond'
@@ -26,23 +26,26 @@ class Orthofinder < Formula
   depends_on 'fastme'
 
   def install
-    venv = virtualenv_create(libexec, 'python3')
+    virtualenv_create(libexec, 'python3')
     system "#{libexec}/bin/pip", 'install', 'numpy', 'scipy'
-    rewrite_shebang detected_python_shebang, 'orthofinder.py',
-                                             'scripts_of/__main__.py',
-                                             'scripts_of/consensus_tree.py',
-                                             'scripts_of/files.py',
-                                             'scripts_of/orthologues.py',
-                                             'scripts_of/program_caller.py',
-                                             'scripts_of/stag.py',
-                                             'scripts_of/stride.py',
-                                             'scripts_of/trim.py',
-                                             'scripts_of/trees_msa.py',
-                                             'tools/convert_orthofinder_tree_ids.py',
-                                             'tools/make_ultrametric.py'
+
+    # detected_python_shebang won't work below becayse it will point to "#!/usr/local/opt/python@3.9/bin/python3"
+    # and we need to point to "<formula_dir>orthofinder/<formula_version>/libexec/bin/python3" 
+    rewrite_shebang python_shebang_rewrite_info("#{libexec}/bin/python3"), 'orthofinder.py',
+                    'scripts_of/__main__.py',
+                    'scripts_of/consensus_tree.py',
+                    'scripts_of/files.py',
+                    'scripts_of/orthologues.py',
+                    'scripts_of/program_caller.py',
+                    'scripts_of/stag.py',
+                    'scripts_of/stride.py',
+                    'scripts_of/trim.py',
+                    'scripts_of/trees_msa.py',
+                    'tools/convert_orthofinder_tree_ids.py',
+                    'tools/make_ultrametric.py'
     # Remove local binaries so the homebrew ones are used instead
     system 'rm', '-rf', 'scripts_of/bin'
-    bin.install "orthofinder.py" => "orthofinder"
+    bin.install 'orthofinder.py' => 'orthofinder'
     bin.install Dir['scripts_of']
     bin.install Dir['tools']
   end

--- a/orthofinder.rb
+++ b/orthofinder.rb
@@ -29,9 +29,9 @@ class Orthofinder < Formula
     virtualenv_create(libexec, 'python3')
     system "#{libexec}/bin/pip", 'install', 'numpy', 'scipy'
 
-    # detected_python_shebang won't work below becayse it will point to "#!/usr/local/opt/python@3.9/bin/python3"
-    # and we need to point to "<formula_dir>orthofinder/<formula_version>/libexec/bin/python3" 
-    rewrite_shebang python_shebang_rewrite_info("#{libexec}/bin/python3"), 'orthofinder.py',
+    # detected_python_shebang won't work below because it will point to "#!/usr/local/opt/python@3.9/bin/python3"
+    # and we need to point to "<linuxbrew_dir>/opt/orthofinder/libexec/bin/python3"
+    rewrite_shebang python_shebang_rewrite_info("#{opt_libexec}/bin/python3"), 'orthofinder.py',
                     'scripts_of/__main__.py',
                     'scripts_of/consensus_tree.py',
                     'scripts_of/files.py',

--- a/orthofinder.rb
+++ b/orthofinder.rb
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 class Orthofinder < Formula
-  include Language::Python::Shebang
   include Language::Python::Virtualenv
 
   desc 'OrthoFinder: phylogenetic orthology inference for comparative genomics'

--- a/orthofinder.rb
+++ b/orthofinder.rb
@@ -31,18 +31,23 @@ class Orthofinder < Formula
 
     # detected_python_shebang won't work below because it will point to "#!/usr/local/opt/python@3.9/bin/python3"
     # and we need to point to "<linuxbrew_dir>/opt/orthofinder/libexec/bin/python3"
-    rewrite_shebang python_shebang_rewrite_info("#{opt_libexec}/bin/python3"), 'orthofinder.py',
-                    'scripts_of/__main__.py',
-                    'scripts_of/consensus_tree.py',
-                    'scripts_of/files.py',
-                    'scripts_of/orthologues.py',
-                    'scripts_of/program_caller.py',
-                    'scripts_of/stag.py',
-                    'scripts_of/stride.py',
-                    'scripts_of/trim.py',
-                    'scripts_of/trees_msa.py',
-                    'tools/convert_orthofinder_tree_ids.py',
-                    'tools/make_ultrametric.py'
+    # can't use built-in "rewrite_shebang" function because Travis uses a very old version of Linuxbrew
+    files = ['orthofinder.py',
+             'scripts_of/__main__.py',
+             'scripts_of/consensus_tree.py',
+             'scripts_of/files.py',
+             'scripts_of/orthologues.py',
+             'scripts_of/program_caller.py',
+             'scripts_of/stag.py',
+             'scripts_of/stride.py',
+             'scripts_of/trim.py',
+             'scripts_of/trees_msa.py',
+             'tools/convert_orthofinder_tree_ids.py',
+             'tools/make_ultrametric.py']
+    inreplace files do |s|
+      s.gsub! %r{^#! ?/usr/bin/(?:env )?python(?:[23](?:\.\d{1,2})?)?( |$)}, "#!#{opt_libexec}/bin/python3"
+    end
+
     # Remove local binaries so the homebrew ones are used instead
     system 'rm', '-rf', 'scripts_of/bin'
     bin.install 'orthofinder.py' => 'orthofinder'


### PR DESCRIPTION
Few bugs fixed in this PR:
1) `bottle :unneeded` is [deprecated](https://github.com/tophat/homebrew-bar/pull/49) -> removed
2) replacing `detected_python_shebang` to `python_shebang_rewrite_info("#{libexec}/bin/python3")` because the former will point to `#!/usr/local/opt/python@3.9/bin/python3`, but we need the python at `<linuxbrew_dir>/opt/orthofinder/libexec/bin/python3`